### PR TITLE
Docs: contributors guide

### DIFF
--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -16,28 +16,27 @@ Setting up your development environment
 Install prerequisites
 ~~~~~~~~~~~~~~~~~~~~~
 
-Podium requires Toga A Python native, OS native GUI toolkit. Follow the instructions
-to install `Toga Prerequisites`_ for your operating system.
+Podium requires Toga_ (A Python native, OS native GUI toolkit).
+Follow the instructions to install `Toga Prerequisites`_ for your operating system.
 
 Setup virtual environment and install Podium
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The recommended way of setting up your development environment for Podium
-is to install a virtual environment, install the required dependencies and
-start coding. Assuming that you are using ``virtualenvwrapper``, you only have
-to run::
+is to create a virtual environment, install Podium in development mode into
+your virtual environment and start coding.
+Assuming that you are using ``virtualenvwrapper``, you only have to run::
 
     $ git clone https://github.com/beeware/podium.git
     $ cd podium
     $ mkvirtualenv podium
-
-Podium uses ``unittest`` for its own test suite as well as additional helper
-modules for testing. To install Podium in development mode, you have to run the
-following command within your virtual environment::
-
     $ pip install -e .
 
 
+Podium uses ``unittest`` for its own test suite as well as additional helper
+modules for testing.
+
 Now you are ready to start hacking! Have fun!
 
+.. _Toga: https://github.com/beeware/toga
 .. _Toga Prerequisites: https://github.com/beeware/toga#prerequisites

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -2,7 +2,8 @@ Contributing to Podium
 ======================
 
 
-If you experience problems with Podium, `log them on GitHub`_. If you want to contribute code, please `fork the code`_ and `submit a pull request`_.
+If you experience problems with Podium, `log them on GitHub`_. If you want to contribute code,
+please `fork the code`_ and `submit a pull request`_.
 
 .. _log them on Github: https://github.com/pybee/podium/issues
 .. _fork the code: https://github.com/pybee/podium
@@ -12,25 +13,31 @@ If you experience problems with Podium, `log them on GitHub`_. If you want to co
 Setting up your development environment
 ---------------------------------------
 
-The recommended way of setting up your development envrionment for Podium
+Install prerequisites
+~~~~~~~~~~~~~~~~~~~~~
+
+Podium requires Toga A Python native, OS native GUI toolkit. Follow the instructions
+to install `Toga Prerequisites`_ for your operating system.
+
+Setup virtual environment and install Podium
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The recommended way of setting up your development environment for Podium
 is to install a virtual environment, install the required dependencies and
 start coding. Assuming that you are using ``virtualenvwrapper``, you only have
 to run::
 
-    $ git clone git@github.com:pybee/podium.git
+    $ git clone https://github.com/beeware/podium.git
     $ cd podium
     $ mkvirtualenv podium
 
-Podium uses ``unittest`` (or ``unittest2`` for Python < 2.7) for its own test
-suite as well as additional helper modules for testing. To install all the
-requirements for Podium, you have to run the following commands within your
-virutal envrionment::
+Podium uses ``unittest`` for its own test suite as well as additional helper
+modules for testing. To install Podium in development mode, you have to run the
+following command within your virtual environment::
 
     $ pip install -e .
-    $ pip install -r requirements_dev.txt
 
-In case you are running a python version ``< 2.7`` please use the
-``requirements_dev.py26.txt`` instead because ``unittest2`` is not part
-of the standard library for these version.
 
 Now you are ready to start hacking! Have fun!
+
+.. _Toga Prerequisites: https://github.com/beeware/toga#prerequisites

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,11 @@ setup(
     include_package_data=True,
     install_requires=[
     ],
+    extras_require={
+        # Automatically installed platform backends
+        ':sys_platform=="darwin"': ['toga-cocoa==0.3.0.dev11'],
+        ':sys_platform=="linux"': ['toga-gtk==0.3.0.dev11'],
+    },
     license='New BSD',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
     ],
     extras_require={
         # Automatically installed platform backends
-        ':sys_platform=="darwin"': ['toga-cocoa==0.3.0.dev11'],
-        ':sys_platform=="linux"': ['toga-gtk==0.3.0.dev11'],
+        ':sys_platform=="darwin"': ['toga-cocoa>=0.3.0.dev11'],
+        ':sys_platform=="linux"': ['toga-gtk>=0.3.0.dev11'],
     },
     license='New BSD',
     classifiers=[
@@ -71,13 +71,13 @@ setup(
         },
         'macos': {
             'app_requires': [
-                'toga-cocoa==0.3.0.dev11'
+                'toga-cocoa>=0.3.0.dev11'
             ],
             'icon': 'icons/podium',
         },
         'linux': {
             'app_requires': [
-                'toga-gtk==0.3.0.dev11'
+                'toga-gtk>=0.3.0.dev11'
             ],
         }
     }

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ with io.open('./src/podium/__init__.py', encoding='utf8') as version_file:
 with io.open('README.rst', encoding='utf8') as readme:
     long_description = readme.read()
 
-
 setup(
     name='podium',
     version=version,
@@ -71,5 +70,10 @@ setup(
             ],
             'icon': 'icons/podium',
         },
-    },
+        'linux': {
+            'app_requires': [
+                'toga-gtk==0.3.0.dev11'
+            ],
+        }
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,6 @@ setup(
     include_package_data=True,
     install_requires=[
     ],
-    extras_require={
-        # Automatically installed platform backends
-        ':sys_platform=="darwin"': ['toga-cocoa>=0.3.0.dev11'],
-        ':sys_platform=="linux"': ['toga-gtk>=0.3.0.dev11'],
-    },
     license='New BSD',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/src/podium/deck.py
+++ b/src/podium/deck.py
@@ -1,8 +1,6 @@
 import os
 from urllib.parse import quote
 
-from rubicon.objc import ObjCClass, objc_method
-
 import toga
 from toga.style import Pack
 
@@ -106,7 +104,6 @@ class SlideDeck(toga.Document):
             defaultThemeFileName = os.path.join(self.app._impl.resource_path, 'app', 'templates', 'default.css')
             with open(defaultThemeFileName, 'r', encoding='utf-8') as data:
                 self.theme = data.read()
-
 
     def show(self):
         self.window_1.redraw()


### PR DESCRIPTION
PR:
   * Add link to instructions how to install Toga prerequisites.
   * Updated example how to install Podium in development mode.
   * Removed Python2.7 instructions since it is no longer supported.

This will close issue #23. 