### PR TITLE
Fix missing hashbang and executable file mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#!/usr/bin/env python
 import io
 import re
 from setuptools import setup, find_packages


### PR DESCRIPTION
The `!` character ("bang!") missing in the first line of `setup.py` and missing executable file permissions on `setup.py` make it impossible to run the setup script as `./setup.py`.

This PR fixes those issues.