### PR TITLE
Updates to support recent changes in Briefcase and Toga

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ local
 macOS
 linux
 windows
+.DS_Store
+venv

--- a/README.rst
+++ b/README.rst
@@ -169,8 +169,9 @@ If you need to debug the CSS for a slide, you may want to use the "inspect
 element" feature of the webview. You may need to enable manually enable the
 feature at an operating system level:
 
-* **macOS**: at a terminal prompt, run
-  `defaults write NSGlobalDomain WebKitDeveloperExtras -bool true`
+* **macOS**: at a terminal prompt, run:
+
+    defaults write org.beeware.podium WebKitDeveloperExtras -bool true
 
 Documentation
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,11 @@ icon = "src/podium/resources/podium-deck"
 url = 'https://beeware.org/project/projects/applications/podium/'
 
 [tool.briefcase.app.podium.macOS]
-requires = ["toga-cocoa>=0.3.0.dev28"]
+# Dev21 is the last version that used WebView, rather than WKWebView
+requires = [
+    "toga-cocoa==0.3.0.dev21",
+    "std-nslog==1.0.1",
+]
 
 [tool.briefcase.app.podium.linux]
-requires = ["toga-gtk>=0.3.0.dev28"]
+requires = ["toga-gtk==0.3.0.dev21"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Podium"
-version = "0.2"
+version = "0.3"
 bundle = "org.beeware"
 author = 'Russell Keith-Magee'
 author_email = 'russell@keith-magee.com'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ icon = "src/podium/resources/podium-deck"
 url = 'https://beeware.org/project/projects/applications/podium/'
 
 [tool.briefcase.app.podium.macOS]
-requires = ["toga-cocoa>=0.3.0.dev16"]
+requires = ["toga-cocoa>=0.3.0.dev28"]
 
 [tool.briefcase.app.podium.linux]
-requires = ["toga-gtk>=0.3.0.dev16"]
+requires = ["toga-gtk>=0.3.0.dev28"]

--- a/src/podium/app.py
+++ b/src/podium/app.py
@@ -8,7 +8,7 @@ from podium.deck import SlideDeck
 class Podium(toga.DocumentApp):
     def __init__(self):
         super().__init__(
-            document_types={'podium': SlideDeck}
+            document_types={'podium': SlideDeck},
         )
 
     # FILE commands ##################################################

--- a/src/podium/app.py
+++ b/src/podium/app.py
@@ -1,5 +1,3 @@
-import os
-
 import toga
 
 from podium.deck import SlideDeck

--- a/src/podium/resources/themes/default/style.css
+++ b/src/podium/resources/themes/default/style.css
@@ -341,7 +341,6 @@ ol > li {
 ol
 {
     list-style-type: none;
-    counter-reset: list-item 0;
 }
 
 .right-column ol


### PR DESCRIPTION
* Pins the implementation to an older version of Toga to retain the older Webkit implementation
* Moves to using `pathlib` instead of `os.path`
* Adds debug to make tracking template debugging easier.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
