### PR TITLE
Update Podium for recent Toga compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,9 @@
 Podium
 ======
 
-.. image:: https://badges.gitter.im/beeware/general.svg
-   :target: https://gitter.im/beeware/general
-
+.. image:: https://img.shields.io/discord/836455665257021440?label=Discord%20Chat&logo=discord&style=plastic
+   :target: https://beeware.org/bee/chat/
+   :alt: Discord server
 
 A markup-based slide presentation tool.
 
@@ -185,7 +185,7 @@ Podium is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `beeware/general`_ channel on Gitter.
+* `Discord <https://beeware.org/bee/chat/>`__
 
 We foster a welcoming and respectful community as described in our
 `BeeWare Community Code of Conduct`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,12 @@ icon = "src/podium/resources/podium-deck"
 url = 'https://beeware.org/project/projects/applications/podium/'
 
 [tool.briefcase.app.podium.macOS]
-# Dev21 is the last version that used WebView, rather than WKWebView
 requires = [
-    "toga-cocoa==0.3.0.dev21",
+    "toga-cocoa==0.3.0.dev39",
     "std-nslog==1.0.1",
 ]
 
 [tool.briefcase.app.podium.linux]
-requires = ["toga-gtk==0.3.0.dev21"]
+requires = [
+    "toga-gtk==0.3.0.dev39"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ url = 'https://beeware.org/project/projects/applications/podium/'
 
 [tool.briefcase.app.podium.macOS]
 requires = [
-    "toga-cocoa==0.3.0.dev39",
+    "toga-cocoa>=0.3.0",
     "std-nslog==1.0.1",
 ]
 
 [tool.briefcase.app.podium.linux]
 requires = [
-    "toga-gtk==0.3.0.dev39"
+    "toga-gtk>=0.3.0"
 ]

--- a/src/podium/app.py
+++ b/src/podium/app.py
@@ -1,6 +1,85 @@
+from http import HTTPStatus
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from threading import Event, Thread
+import re
+import webbrowser
+
 import toga
 
 from podium.deck import SlideDeck
+
+
+class DeckHTTPHandler(SimpleHTTPRequestHandler):
+    DECK_URL_RE = re.compile("^/deck/([a-z\d]+)/(slides|notes|print)$")
+    def do_GET(self):
+        # Look for the URLs for dynamic deck content:
+        #     /deck/<id>/slides
+        #     /deck/<id>/notes
+        #     /deck/<id>/print
+        # If you find one of those, defer to the deck to build the
+        # content dynamically, and build the GET response. All other
+        # content is served statically; however, the path to that
+        # content will be different depending on whether it's
+        # builtin content or deck content.
+        match = self.DECK_URL_RE.match(self.path)
+        if match:
+            deck = self.server.app.deck_for_id(match[1])
+            if match[2] == "slides":
+                content = deck.window_1.html_content()
+            elif match[2] == "notes":
+                content = deck.window_2.html_content()
+            elif match[2] == "print":
+                content = deck.html_content()
+            else:
+                self.send_error(HTTPStatus.NOT_FOUND, f"Unknown deck content {match[2]!r}")
+                return
+            self.send_response(200)
+            self.send_header("Content-type", "text/html")
+            self.send_header("Content-Length", len(content))
+            self.end_headers()
+            self.wfile.write(content)
+        else:
+            #
+            super().do_GET()
+
+    def translate_path(self, path):
+        if path == "/favicon.ico":
+            # Favicon is a special case
+            return str(self.server.resources_path / "podium.png")
+        elif path.startswith('/resources/'):
+            # Any URL starting with /resources/ is static app-based content
+            return str(self.server.resources_path / path[11:])
+        elif path.startswith('/deck/'):
+            # Any URL starting with /deck is deck-based content, except for
+            # the slide/notes/print dynamic content, which is handled by do_GET
+            try:
+                parts = path.split('/', 3)
+                deck = self.server.app.deck_for_id(parts[2])
+                return f"{deck.filename}/{parts[3]}"
+            except KeyError:
+                self.send_error(HTTPStatus.NOT_FOUND, "Deck not found")
+                return None
+        else:
+            # Any other URL is unknown content.
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
+
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        super().end_headers()
+
+
+class PodiumHTTPServer(HTTPServer):
+    def __init__(self, app):
+        self.app = app
+        # Use port 0 to let the server select an available port.
+        super().__init__(("127.0.0.1", 0), DeckHTTPHandler)
+
+    @property
+    def resources_path(self):
+        return self.app.paths.app / "resources"
 
 
 class Podium(toga.DocumentApp):
@@ -9,10 +88,44 @@ class Podium(toga.DocumentApp):
             document_types={'podium': SlideDeck},
         )
 
+        self.server_exists = Event()
+        self.server_thread = Thread(target=self.web_server)
+        self.server_thread.start()
+
+        self.on_exit = self.cleanup
+
+        self.server_exists.wait()
+        self.server_host, self.server_port = self._httpd.socket.getsockname()
+        print(f"Serving on {self.server_host}:{self.server_port}")
+
+    # Web server #####################################################
+
+    def web_server(self):
+        print("Starting server...")
+        self._httpd = PodiumHTTPServer(self)
+        # The server is now listening, but connections will block until
+        # serve_forever is run.
+        self.server_exists.set()
+        self._httpd.serve_forever()
+
+    def cleanup(self, app, **kwargs):
+        print("Shutting down...")
+        self._httpd.shutdown()
+        return True
+
+    def deck_for_id(self, deck_id):
+        return {
+            doc.file_sha: doc
+            for doc in self.documents
+        }[deck_id]
+
     # FILE commands ##################################################
 
     async def reload(self, widget, **kwargs):
         await self.current_window.deck.reload()
+
+    def print(self, widget, **kwargs):
+        webbrowser.open(f"{self.current_window.deck.base_url}/print")
 
     # PLAY commands ##################################################
 
@@ -49,24 +162,31 @@ class Podium(toga.DocumentApp):
         self.commands.add(
             toga.Command(
                 self.reload,
-                label='Reload slide deck',
+                text='Reload slide deck',
                 shortcut=toga.Key.MOD_1 + 'r',
                 group=toga.Group.FILE,
                 section=1
+            ),
+            toga.Command(
+                self.print,
+                text='Print...',
+                shortcut=toga.Key.MOD_1 + 'p',
+                group=toga.Group.FILE,
+                section=2
             ),
         )
         self.commands.add(
             toga.Command(
                 self.play,
-                label='Play slideshow',
-                shortcut=toga.Key.MOD_1 + 'p',
+                text='Play slideshow',
+                shortcut=toga.Key.MOD_1 + 'P',
                 group=play_group,
                 section=0,
                 order=0,
             ),
             toga.Command(
                 self.reset_timer,
-                label='Reset timer',
+                text='Reset timer',
                 shortcut=toga.Key.MOD_1 + 't',
                 group=play_group,
                 section=0,
@@ -74,7 +194,7 @@ class Podium(toga.DocumentApp):
             ),
             toga.Command(
                 self.next_slide,
-                label='Next slide',
+                text='Next slide',
                 shortcut=toga.Key.RIGHT,
                 group=play_group,
                 section=1,
@@ -82,7 +202,7 @@ class Podium(toga.DocumentApp):
             ),
             toga.Command(
                 self.previous_slide,
-                label='Previous slide',
+                text='Previous slide',
                 shortcut=toga.Key.LEFT,
                 group=play_group,
                 section=1,
@@ -90,7 +210,7 @@ class Podium(toga.DocumentApp):
             ),
             toga.Command(
                 self.first_slide,
-                label='First slide',
+                text='First slide',
                 shortcut=toga.Key.HOME,
                 group=play_group,
                 section=1,
@@ -98,7 +218,7 @@ class Podium(toga.DocumentApp):
             ),
             toga.Command(
                 self.last_slide,
-                label='Last slide',
+                text='Last slide',
                 shortcut=toga.Key.END,
                 group=play_group,
                 section=1,
@@ -108,13 +228,13 @@ class Podium(toga.DocumentApp):
         self.commands.add(
             toga.Command(
                 self.switch_screens,
-                label='Switch screens',
+                text='Switch screens',
                 shortcut=toga.Key.MOD_1 + toga.Key.TAB,
                 group=view_group,
             ),
             toga.Command(
                 self.change_aspect_ratio,
-                label='Change aspect ratio',
+                text='Change aspect ratio',
                 shortcut=toga.Key.MOD_1 + 'a',
                 group=view_group,
             ),

--- a/src/podium/deck.py
+++ b/src/podium/deck.py
@@ -32,14 +32,12 @@ class PrimarySlideWindow(toga.MainWindow):
         return self.deck.resource_path / "slide-template.html"
 
     def html_content(self):
-        print(f"Loading slide template from {self.template_path}")
         with self.template_path.open('r', encoding="utf-8") as data:
             template = data.read()
 
         html = template.format(
             resource_path=self.deck.resource_path,
             theme=self.deck.theme,
-            style_overrides=self.deck.style_overrides,
             aspect_ratio_tag=self.deck.aspect.replace(':', '-'),
             aspect_ratio=self.deck.aspect,
             title=self.deck.title,
@@ -83,14 +81,12 @@ class SecondarySlideWindow(toga.Window):
         return self.deck.resource_path / "notes-template.html"
 
     def html_content(self):
-        print(f"Loading notes template from {self.template_path}")
         with self.template_path.open('r', encoding='utf-8') as data:
             template = data.read()
 
         html = template.format(
             resource_path=self.deck.resource_path,
             theme=self.deck.theme,
-            style_overrides=self.deck.style_overrides,
             aspect_ratio_tag=self.deck.aspect.replace(':', '-'),
             aspect_ratio=self.deck.aspect,
             title=self.deck.title,
@@ -144,26 +140,16 @@ class SlideDeck(toga.Document):
         if self.file_path.is_dir():
             # Multi-file .podium files must contain slides.md;
             # may contain style.css
-            styleFile = self.file_path / "style.css"
             contentFile = self.file_path / "slides.md"
 
             print(f"Loading content from {contentFile}")
             with open(contentFile, 'r', encoding='utf-8') as f:
                 self.content = f.read()
-
-            if styleFile.exists():
-                print(f"Loading style overrides from {styleFile}")
-                with styleFile.open('r', encoding='utf-8') as f:
-                    self.style_overrides = f.read()
-            else:
-                print(f"No style overrides")
-                self.style_overrides = ''
         else:
             # Single file can just be a standalone markdown file
             print(f"Loading content from {self.file_path}")
             with self.file_path.open('r', encoding='utf-8') as f:
                 self.content = f.read()
-            self.style_overrides = ''
 
     def show(self):
         self.window_1.redraw()
@@ -181,14 +167,12 @@ class SlideDeck(toga.Document):
         return self.resource_path / "print-template.html"
 
     def html_content(self):
-        print(f"Loading print template from {self.print_template_path}")
         with self.print_template_path.open('r', encoding='utf-8') as data:
             template = data.read()
 
         html = template.format(
             resource_path=self.resource_path,
             theme=self.theme,
-            style_overrides=self.style_overrides,
             aspect_ratio_tag=self.aspect.replace(':', '-'),
             aspect_ratio=self.aspect,
             title=self.title,

--- a/src/podium/resources/notes-template.html
+++ b/src/podium/resources/notes-template.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Title</title>
+    <title>{title}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <link href="file://{resource_path}/themes/{theme}/style.css" type="text/css" rel="stylesheet">
+    <link href="/resources/themes/{theme}/style.css" type="text/css" rel="stylesheet">
     <!-- Notes template doesn't need animations link-->
     <style>
       /* Don't display the original source */
@@ -15,11 +15,11 @@
   </head>
   <body class="aspect-{aspect_ratio_tag}">
     <textarea id="source">
-background-image: url({resource_path}/test-pattern.{aspect_ratio_tag}.png)
+background-image: url(/resources/test-pattern.{aspect_ratio_tag}.png)
 ---
 {slide_content}
     </textarea>
-    <script src="file://{resource_path}/remark.js" type="text/javascript">
+    <script src="/resources/remark.js" type="text/javascript">
     </script>
     <script type="text/javascript">
       var slideshow = remark.create({{
@@ -31,4 +31,3 @@ background-image: url({resource_path}/test-pattern.{aspect_ratio_tag}.png)
     </script>
   </body>
 </html>
-

--- a/src/podium/resources/notes-template.html
+++ b/src/podium/resources/notes-template.html
@@ -5,12 +5,13 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link href="/resources/themes/{theme}/style.css" type="text/css" rel="stylesheet">
     <!-- Notes template doesn't need animations link-->
+    <!-- style overrides from the slide deck itself -->
+    <link href="./style.css" type="text/css" rel="stylesheet">
     <style>
       /* Don't display the original source */
       #source {{
           display: none;
       }}
-{style_overrides}
     </style>
   </head>
   <body class="aspect-{aspect_ratio_tag}">

--- a/src/podium/resources/print-template.html
+++ b/src/podium/resources/print-template.html
@@ -1,49 +1,51 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Title</title>
+    <title>{title}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <link href="/resources/themes/{theme}/style.css" type="text/css" rel="stylesheet">
+    <!-- Print template doesn't need animations link-->
     <style>
-/* Don't display the original source */
-#source {
-    display: none;
-}
-    </style>
-    <!-- Print template doesn't need animations href="%s/animate.css" type="text/css" rel="stylesheet"-->
-    <style>
-%s
+      /* Don't display the original source */
+      #source {{
+          display: none;
+      }}
+{style_overrides}
 
 /* Overrides for printing */
-.remark-slide {
+.remark-slide {{
     -webkit-print-color-adjust: exact;
-}
-    
-.remark-container {
+}}
+
+.remark-container {{
     overflow: visible;
     background-color: #fff;
-}
+}}
 
-.remark-slide-container {
+.remark-slide-container {{
     display: block;
     position: relative;
-}
+}}
 
-.remark-slide-scaler {
+.remark-slide-scaler {{
     -moz-box-shadow: none;
     -webkit-box-shadow: none;
     box-shadow: none;
-}
+}}
     </style>
   </head>
   <body>
     <textarea id="source">
-%s
+{slide_content}
     </textarea>
-    <script src="%s/remark.js" type="text/javascript">
+    <script src="/resources/remark.js" type="text/javascript">
     </script>
     <script type="text/javascript">
-      var slideshow = remark.create({controller: function() {}});
-      slideshow.gotoSlide(%s);
+      var slideshow = remark.create({{
+        ratio: "{aspect_ratio}",
+        controller: function() {{}}
+      }});
+      slideshow.gotoSlide({slide_number});
     </script>
   </body>
 </html>

--- a/src/podium/resources/print-template.html
+++ b/src/podium/resources/print-template.html
@@ -5,33 +5,34 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link href="/resources/themes/{theme}/style.css" type="text/css" rel="stylesheet">
     <!-- Print template doesn't need animations link-->
+    <!-- style overrides from the slide deck itself -->
+    <link href="./style.css" type="text/css" rel="stylesheet">
     <style>
       /* Don't display the original source */
       #source {{
           display: none;
       }}
-{style_overrides}
 
-/* Overrides for printing */
-.remark-slide {{
-    -webkit-print-color-adjust: exact;
-}}
+      /* Overrides for printing */
+      .remark-slide {{
+          -webkit-print-color-adjust: exact;
+      }}
 
-.remark-container {{
-    overflow: visible;
-    background-color: #fff;
-}}
+      .remark-container {{
+          overflow: visible;
+          background-color: #fff;
+      }}
 
-.remark-slide-container {{
-    display: block;
-    position: relative;
-}}
+      .remark-slide-container {{
+          display: block;
+          position: relative;
+      }}
 
-.remark-slide-scaler {{
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-}}
+      .remark-slide-scaler {{
+          -moz-box-shadow: none;
+          -webkit-box-shadow: none;
+          box-shadow: none;
+      }}
     </style>
   </head>
   <body>

--- a/src/podium/resources/slide-template.html
+++ b/src/podium/resources/slide-template.html
@@ -3,8 +3,8 @@
   <head>
     <title>Title</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <link href="file://{resource_path}/themes/{theme}/style.css" type="text/css" rel="stylesheet">
-    <link href="file://{resource_path}/animate.css" type="text/css" rel="stylesheet">
+    <link href="/resources/themes/{theme}/style.css" type="text/css" rel="stylesheet">
+    <link href="/resources/animate.css" type="text/css" rel="stylesheet">
     <style>
       /* Don't display the original source */
       #source {{
@@ -15,11 +15,11 @@
   </head>
   <body class="aspect-{aspect_ratio_tag}">
     <textarea id="source">
-background-image: url({resource_path}/test-pattern.{aspect_ratio_tag}.png)
+background-image: url(/resources/test-pattern.{aspect_ratio_tag}.png)
 ---
 {slide_content}
     </textarea>
-    <script src="file://{resource_path}/remark.js" type="text/javascript">
+    <script src="/resources/remark.js" type="text/javascript">
     </script>
     <script type="text/javascript">
       var slideshow = remark.create({{

--- a/src/podium/resources/slide-template.html
+++ b/src/podium/resources/slide-template.html
@@ -5,12 +5,13 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link href="/resources/themes/{theme}/style.css" type="text/css" rel="stylesheet">
     <link href="/resources/animate.css" type="text/css" rel="stylesheet">
+    <!-- style overrides from the slide deck itself -->
+    <link href="./style.css" type="text/css" rel="stylesheet">
     <style>
       /* Don't display the original source */
       #source {{
           display: none;
       }}
-{style_overrides}
     </style>
   </head>
   <body class="aspect-{aspect_ratio_tag}">

--- a/src/podium/resources/themes/default/style.css
+++ b/src/podium/resources/themes/default/style.css
@@ -6,21 +6,21 @@
   font-family: 'Droid Serif';
   font-style: normal;
   font-weight: 400;
-  src: url(./DroidSerif.woff) format('woff');
+  src: url(/resources/themes/default/DroidSerif.woff) format('woff');
 }
 
 @font-face {
   font-family: 'Yanone Kaffeesatz';
   font-style: normal;
   font-weight: 400;
-  src: url(./YanoneKaffeesatz-Regular.woff) format('woff');
+  src: url(/resources/themes/default/YanoneKaffeesatz-Regular.woff) format('woff');
 }
 
 @font-face {
   font-family: 'Ubuntu Mono';
   font-style: normal;
   font-weight: 400;
-  src: url(./UbuntuMono-Regular.woff) format('woff');
+  src: url(/resources/themes/default/UbuntuMono-Regular.woff) format('woff');
 }
 
 /*******************************


### PR DESCRIPTION
Updates Podium to reflect recent API changes in Toga.

The most notable of these is the move to WKWebView on Cocoa; WKWebView doesn't (easily) support the use of `file:///` URLs, so a local fileserver is needed. 

This has the added bonus of giving much better control over exactly what content is served from where - themes, content caching, and "default resources" are a lot easier to handle when there's a web server acting as a proxy for web content.

It also means we're able to introduce a "print" command that can use a Print template to render in a a web browser. This isn't a true "print", as we're still relying on a browser to do the printing, but it means printing a deck is a lot easier.

Requires beeware/toga#1658, so it can't be merged *quite* yet.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
