### PR TITLE
Disambiguate Present vs Print commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,8 @@ it in Podium.
 
 Controls from here are keyboard based:
 
-* CMD-P - Enter presentation mode; or, if in presentation mode, Pause timer
+* CMD-Shift-P - Enter presentation mode; or, if in presentation mode, Pause timer
+* CMD-P - Open presentation in Print view
 * Esc - Exit presentation mode
 * CMD-Tab - Switch displays
 * Right/Left arrows - Next/previous slide


### PR DESCRIPTION
Additional to change in #59, ensure `p` and `P` commands are documented, specifically that the keyboard command requires <kbd>Shift</kbd>

Notes: 
 * because the README is written in `rst`, you can't use `kbd` formatting. 
 * there are still other misses in this list of commands (compared to the commands listed in the app's menu).
   * specifically, a self-built trunk of podium today doesn't appear to support Up/Down, Enter, CMD-A or Cmd-T commands. 

