### PR TITLE
Update Podium to use Toga 0.5.1 APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ _build
 distribute-*
 local
 .DS_Store
-venv
+venv*
+.venv*
 logs

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,0 @@
-Podium was originally created in August 2016.
-
-The PRIMARY AUTHORS are (and/or have been):
-    Russell Keith-Magee
-
-And here is an inevitably incomplete list of MUCH-APPRECIATED CONTRIBUTORS --
-people who have submitted patches, reported bugs, added translations, helped
-answer newbie questions, and generally made Podium that much better:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,9 @@
+# Podium Release Notes
+
+# In development
+
+* Updated to use Toga 0.5.1, and new Document-based app structure
+
+# v0.2 (2 Jan 2020)
+
+* First formal release. Includes macOS and Linux support.

--- a/README.rst
+++ b/README.rst
@@ -78,16 +78,6 @@ file dialog, prompting you to open a ``.podium`` slide deck. An example Podium
 slide deck is also available in the releases folder. Unzip the deck, and open
 it in Podium.
 
-.. note::
-
-    The Linux AppImage format is a cross-platform binary that should run on
-    any Linux distribution using GLibC 2.23 or later - this includes Ubuntu
-    16.04 and later, Fedora 24 and later, and others.
-
-    After downloading the AppImage, you may need to mark the AppImage file as
-    executable (``chmod +x Podium-*.AppImage``) first. In Linux, ``.podium``
-    files appear as directories; select the directory and click ``Open``.
-
 Controls from here are keyboard based:
 
 * CMD-Shift-P - Enter presentation mode; or, if in presentation mode, Pause timer
@@ -117,10 +107,10 @@ If you're using Linux, you'll need to install some system packages first::
 
     # Ubuntu/Debian
     $ sudo apt-get update
-    $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0
+    $ sudo apt-get install python3-dev libgirepository2.0-dev libcairo2-dev libpango1.0-dev gir1.2-gtk-3.0 libcanberra-gtk3-module gir1.2-webkit2-4.1
 
     # Fedora
-    $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3
+    $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel gtk3 cairo-gobject-devel pango-devel libcanberra-gtk3 webkit2gtk4.1
 
 
 Then, you can create a virtual environment and install the BeeWare tools::
@@ -129,7 +119,7 @@ Then, you can create a virtual environment and install the BeeWare tools::
     $ cd beeware
     $ python3 -m venv venv
     $ source venv/bin/activate
-    (venv) $ pip install --pre beeware
+    (venv) $ pip install briefcase
 
 Now that you have the code, you can clone the Podium repository and run it in
 developer mode::
@@ -147,15 +137,9 @@ Use `Briefcase`_ to package this repository as a standalone application::
 
     $ briefcase package
 
-Depending on your platform, this will produce a ``macOS`` folder containing
-a Podium DMG file, or a ``linux`` folder containing a ``.AppImage`` file.
-
-.. note::
-
-    Packaging cross-distribution Linux binaries is a complex process; See `the
-    notes on AppImage packaging
-    <https://briefcase.readthedocs.io/en/latest/reference/platforms/linux/appimage.html>`__
-    in the Briefcase documentation for more details.
+Depending on your platform, this will produce a ``macOS`` folder containing a
+Podium DMG file, or a ``linux`` folder containing a system package appropriate
+to your distribution (a `.deb`, `.rpm` or `.pkg.zip` file)
 
 Overriding Default themes
 -------------------------

--- a/README.rst
+++ b/README.rst
@@ -107,10 +107,10 @@ If you're using Linux, you'll need to install some system packages first::
 
     # Ubuntu/Debian
     $ sudo apt-get update
-    $ sudo apt-get install python3-dev libgirepository2.0-dev libcairo2-dev libpango1.0-dev gir1.2-gtk-3.0 libcanberra-gtk3-module gir1.2-webkit2-4.1
+    $ sudo apt-get install python3-dev libgirepository2.0-dev libcairo2-dev libpango1.0-dev gir1.2-gtk-3.0 libcanberra-gtk3-module gir1.2-webkit2-4.1 dpkg-dev
 
     # Fedora
-    $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel gtk3 cairo-gobject-devel pango-devel libcanberra-gtk3 webkit2gtk4.1
+    $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel gtk3 cairo-gobject-devel pango-devel libcanberra-gtk3 webkit2gtk4.1 rpm-build
 
 
 Then, you can create a virtual environment and install the BeeWare tools::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ description = "Podium Slide Deck"
 extension = "podium"
 icon = "icons/podium-deck"
 url = 'https://beeware.org/project/projects/applications/podium/'
+macOS.UTTypeConformsTo = ["com.apple.package", "public.content"]
 
 [tool.briefcase.app.podium.macOS]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,107 @@ requires = [
     "toga-gtk==0.5.1"
 ]
 
+[tool.briefcase.app.podium.linux.system.debian]
+system_requires = [
+    # Needed to compile pycairo wheel
+    "libcairo2-dev",
+    "libgirepository-2.0-dev",
+]
+
+system_runtime_requires = [
+    # Needed to provide GTK and its GI bindings
+    "gir1.2-gtk-3.0",
+    "libgirepository-2.0-0",
+    # Dependencies that GTK looks for at runtime
+    "libcanberra-gtk3-module",
+    # Needed to provide WebKit2 at runtime
+    # Note: Debian 11 requires gir1.2-webkit2-4.0 instead
+    "gir1.2-webkit2-4.1",
+]
+
+[tool.briefcase.app.podium.linux.system.rhel]
+system_requires = [
+    # Needed to compile pycairo wheel
+    "cairo-gobject-devel",
+    # Needed to compile PyGObject wheel
+    "gobject-introspection-devel",
+]
+
+system_runtime_requires = [
+    # Needed to support Python bindings to GTK
+    "gobject-introspection",
+    # Needed to provide GTK
+    "gtk3",
+    # Dependencies that GTK looks for at runtime
+    "libcanberra-gtk3",
+    # Needed to provide WebKit2 at runtime
+    "webkit2gtk4.1",
+]
+
+[tool.briefcase.app.podium.linux.system.suse]
+system_requires = [
+    # Needed to compile pycairo wheel
+    "cairo-devel",
+    # Needed to compile PyGObject wheel
+    "gobject-introspection-devel",
+]
+
+system_runtime_requires = [
+    # Needed to provide GTK
+    "gtk3",
+    # Needed to support Python bindings to GTK
+    "gobject-introspection", "typelib(Gtk) = 3.0",
+    # Dependencies that GTK looks for at runtime
+    "libcanberra-gtk3-module",
+    # Needed to provide WebKit2 at runtime
+    "libwebkit2gtk3", "typelib(WebKit2)",
+]
+
+[tool.briefcase.app.podium.linux.system.arch]
+system_requires = [
+    # Needed to compile pycairo wheel
+    "cairo",
+    # Needed to compile PyGObject wheel
+    "gobject-introspection",
+    # Runtime dependencies that need to exist so that the
+    # Arch package passes final validation.
+    # Needed to provide GTK
+    "gtk3",
+    # Dependencies that GTK looks for at runtime
+    "libcanberra",
+    # Needed to provide WebKit2
+    "webkit2gtk",
+]
+
+system_runtime_requires = [
+    # Needed to provide GTK
+    "gtk3",
+    # Needed to provide PyGObject bindings
+    "gobject-introspection-runtime",
+    # Dependencies that GTK looks for at runtime
+    "libcanberra",
+    # Needed to provide WebKit2 at runtime
+    "webkit2gtk",
+]
+
+[tool.briefcase.app.podium.linux.appimage]
+supported = false
+
+[tool.briefcase.app.podium.linux.flatpak]
+flatpak_runtime = "org.gnome.Platform"
+flatpak_runtime_version = "48"
+flatpak_sdk = "org.gnome.Sdk"
+
 [tool.briefcase.app.podium.windows]
 requires = [
     "toga-winforms==0.5.1"
 ]
+
+[tool.briefcase.app.podium.iOS]
+supported = false
+
+[tool.briefcase.app.podium.android]
+supported = false
+
+[tool.briefcase.app.podium.web]
+supported = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,16 @@ url = 'https://beeware.org/project/projects/applications/podium/'
 
 [tool.briefcase.app.podium.macOS]
 requires = [
-    "toga-cocoa==0.4.6",
+    "toga-cocoa==0.5.1",
     "std-nslog==1.0.1",
 ]
 
 [tool.briefcase.app.podium.linux]
 requires = [
-    "toga-gtk==0.4.6"
+    "toga-gtk==0.5.1"
 ]
 
 [tool.briefcase.app.podium.windows]
 requires = [
-    "toga-winforms==0.4.6"
+    "toga-winforms==0.5.1"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ homepage = 'https://beeware.org/project/projects/applications/podium'
 [tool.briefcase.app.podium]
 formal_name = "Podium"
 description = "A presentation tool for developers."
+long_description = """A slide presentation tool.
+
+It is focussed on developer needs, using Markdown as a slide format.
+"""
 sources = ["src/podium"]
 icon = "icons/podium"
 

--- a/src/podium/app.py
+++ b/src/podium/app.py
@@ -56,7 +56,7 @@ class DeckHTTPHandler(SimpleHTTPRequestHandler):
             try:
                 parts = path.split('/', 3)
                 deck = self.server.app.deck_for_id(parts[2])
-                return f"{deck.path}/{parts[3]}"
+                return f"{deck.content_path}/{parts[3]}"
             except KeyError:
                 self.send_error(HTTPStatus.NOT_FOUND, "Deck not found")
                 return None

--- a/src/podium/app.py
+++ b/src/podium/app.py
@@ -198,7 +198,7 @@ class Podium(toga.App):
         self.stop_command = toga.Command(
                 self.stop,
                 text='Stop slideshow',
-                shortcut=toga.Key.ESCAPE,
+                shortcut=toga.Key.MOD_1 + toga.Key.ESCAPE,
                 group=play_group,
                 section=0,
                 order=1,

--- a/src/podium/app.py
+++ b/src/podium/app.py
@@ -163,6 +163,9 @@ class Podium(toga.App):
     def change_aspect_ratio(self, widget, **kwargs):
         self.current_window.doc.change_aspect_ratio()
 
+    def open_in_browser(self, widget, **kwargs):
+        webbrowser.open(f"{self.current_window.doc.base_url}/slides")
+
     def startup(self):
         # Document-based app; no main window.
         self.main_window = None
@@ -259,6 +262,11 @@ class Podium(toga.App):
                 self.change_aspect_ratio,
                 text='Change aspect ratio',
                 shortcut=toga.Key.MOD_1 + 'a',
+                group=view_group,
+            ),
+            toga.Command(
+                self.open_in_browser,
+                text='Open in browser',
                 group=view_group,
             ),
         )

--- a/src/podium/deck.py
+++ b/src/podium/deck.py
@@ -29,7 +29,6 @@ class PrimarySlideWindow(toga.DocumentWindow):
         super().__init__(
             doc=doc,
             size=size_for_aspect(doc.aspect),
-            on_close=self.close_all
         )
         self.create()
 
@@ -65,9 +64,9 @@ class PrimarySlideWindow(toga.DocumentWindow):
     def redraw(self):
         self.html_view.url = f"{self.doc.base_url}/slides"
 
-    def close_all(self, window, **kwargs):
+    def close(self):
         self.secondary.close()
-        return True
+        super().close()
 
 
 class SecondarySlideWindow(toga.Window):

--- a/src/podium/deck.py
+++ b/src/podium/deck.py
@@ -138,6 +138,13 @@ class SlideDeck(toga.Document):
     def resource_path(self):
         return self.app.paths.app / 'resources'
 
+    @property
+    def content_path(self):
+        if self.path and self.path.suffix == ".md":
+            return self.path.parent
+        else:
+            return self.path
+
     def read(self):
         if self.path.is_dir():
             # Multi-file .podium files must contain slides.md;


### PR DESCRIPTION
It's been a long time since there's been a Podium release, and there's been some bitrot as a result.

This updates Podium to use Toga 0.5.1 APIs, in particular adapting to changes in the Document-based app API, and a change to the handling of keyboard events in WebView.

Refs #64.
Fixes #68 
Fixes #75
Fixes #76

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
